### PR TITLE
Ability to define a custom mMinTouchTargetSize

### DIFF
--- a/library/src/main/java/me/zhanghai/android/fastscroll/FastScroller.java
+++ b/library/src/main/java/me/zhanghai/android/fastscroll/FastScroller.java
@@ -29,13 +29,13 @@ import android.view.ViewGroupOverlay;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import java.util.Objects;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.math.MathUtils;
 import androidx.core.util.Consumer;
+
+import java.util.Objects;
 
 public class FastScroller {
 
@@ -81,11 +81,15 @@ public class FastScroller {
     public FastScroller(@NonNull ViewGroup view, @NonNull ViewHelper viewHelper,
                         @Nullable Rect padding, @NonNull Drawable trackDrawable,
                         @NonNull Drawable thumbDrawable, @NonNull Consumer<TextView> popupStyle,
-                        @NonNull AnimationHelper animationHelper) {
+                        @NonNull AnimationHelper animationHelper, int minTouchTargetSize) {
 
-        mMinTouchTargetSize = view.getResources().getDimensionPixelSize(
-                R.dimen.afs_min_touch_target_size);
         Context context = view.getContext();
+
+        if (minTouchTargetSize > -1)
+            mMinTouchTargetSize = Utils.dpToPixel(context, minTouchTargetSize);
+        else
+            mMinTouchTargetSize = view.getResources().getDimensionPixelSize(R.dimen.afs_min_touch_target_size);
+
         mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
 
         mView = view;

--- a/library/src/main/java/me/zhanghai/android/fastscroll/FastScrollerBuilder.java
+++ b/library/src/main/java/me/zhanghai/android/fastscroll/FastScrollerBuilder.java
@@ -42,6 +42,8 @@ public class FastScrollerBuilder {
     @Nullable
     private PopupTextProvider mPopupTextProvider;
 
+    private int mMinTouchTargetSize = -1;
+
     @Nullable
     private Rect mPadding;
 
@@ -71,6 +73,12 @@ public class FastScrollerBuilder {
     @NonNull
     public FastScrollerBuilder setPopupTextProvider(@Nullable PopupTextProvider popupTextProvider) {
         mPopupTextProvider = popupTextProvider;
+        return this;
+    }
+
+    @NonNull
+    public FastScrollerBuilder setMinTouchTargetSize(int sizeDp) {
+        mMinTouchTargetSize = sizeDp;
         return this;
     }
 
@@ -145,7 +153,7 @@ public class FastScrollerBuilder {
     @NonNull
     public FastScroller build() {
         return new FastScroller(mView, getOrCreateViewHelper(), mPadding, mTrackDrawable,
-                mThumbDrawable, mPopupStyle, getOrCreateAnimationHelper());
+                mThumbDrawable, mPopupStyle, getOrCreateAnimationHelper(), mMinTouchTargetSize);
     }
 
     @NonNull

--- a/library/src/main/java/me/zhanghai/android/fastscroll/Utils.java
+++ b/library/src/main/java/me/zhanghai/android/fastscroll/Utils.java
@@ -19,6 +19,7 @@ package me.zhanghai.android.fastscroll;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
+import android.util.DisplayMetrics;
 
 import androidx.annotation.AttrRes;
 import androidx.annotation.ColorInt;
@@ -37,7 +38,7 @@ class Utils {
     @Nullable
     public static ColorStateList getColorStateListFromAttrRes(@AttrRes int attrRes,
                                                               @NonNull Context context) {
-        TypedArray a = context.obtainStyledAttributes(new int[] { attrRes });
+        TypedArray a = context.obtainStyledAttributes(new int[]{attrRes});
         int resId;
         try {
             resId = a.getResourceId(0, 0);
@@ -48,5 +49,10 @@ class Utils {
         } finally {
             a.recycle();
         }
+    }
+
+    public static int dpToPixel(@NonNull final Context context, int dp) {
+        float scaleFactor = (1.0f / DisplayMetrics.DENSITY_DEFAULT) * context.getResources().getDisplayMetrics().densityDpi;
+        return (int) (dp * scaleFactor);
     }
 }


### PR DESCRIPTION
New `FastScrollerBuilder.setMinTouchTargetSize`  method to define a custom touch target size (in dp).

My users and I thought the default 48dp size was too large.