### PR TITLE
Fix crashing issue when total vertical padding is larger than the View's height

### DIFF
--- a/library/src/main/java/me/zhanghai/android/fastscroll/FastScroller.java
+++ b/library/src/main/java/me/zhanghai/android/fastscroll/FastScroller.java
@@ -189,7 +189,7 @@ public class FastScroller {
         Rect padding = getPadding();
         int trackLeft = isLayoutRtl ? padding.left : viewWidth - padding.right - mTrackWidth;
         layoutView(mTrackView, trackLeft, padding.top, trackLeft + mTrackWidth,
-                viewHeight - padding.bottom);
+                Math.max(viewHeight - padding.bottom, padding.top));
         int thumbLeft = isLayoutRtl ? padding.left : viewWidth - padding.right - mThumbWidth;
         int thumbTop = padding.top + mThumbOffset;
         layoutView(mThumbView, thumbLeft, thumbTop, thumbLeft + mThumbWidth,


### PR DESCRIPTION
Hi. I noticed that AndroidFastScroll can cause weird app crashing in a certain situation.

## The crash log message

Here's the extracted message from the Logcat when my app crashed. 

I can see **an error occurred in the `RenderThread` thread and someone trying to create a negative height  (`-196 px`) View**.

```
A/libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 5715 (RenderThread), pid 5581 (***)
Abort message: 'JNI DETECTED ERROR IN APPLICATION: JNI CallVoidMethodV called with pending exception java.lang.IllegalStateException: Unable to create layer for View, size 64x-192 max size 16384 color type 4 has context 1
    (Throwable with empty stack trace)    
```

## Investigation result

When FastScroller attached view's height is smaller than its total vertical padding, the track view created in FastScroller will be requested to layout with inappropriate coordinates.

## Proposed fix

Cramping the bottom position value with the top position value not to request negative height when layout the track view.