### PR TITLE
fix: fix android:tint bug

### DIFF
--- a/library/src/main/res/drawable/afs_md2_thumb.xml
+++ b/library/src/main/res/drawable/afs_md2_thumb.xml
@@ -22,8 +22,9 @@
   -->
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" 
     android:shape="rectangle"
-    android:tint="?colorControlActivated">
+    app:tint="?colorControlActivated">
 
     <corners android:radius="8dp" />
 

--- a/library/src/main/res/drawable/afs_md2_track.xml
+++ b/library/src/main/res/drawable/afs_md2_track.xml
@@ -22,8 +22,9 @@
   -->
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" 
     android:shape="rectangle"
-    android:tint="?colorControlNormal">
+    app:tint="?colorControlNormal">
 
     <corners android:radius="8dp" />
 

--- a/library/src/main/res/drawable/afs_popup_background.xml
+++ b/library/src/main/res/drawable/afs_popup_background.xml
@@ -22,8 +22,9 @@
   -->
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" 
     android:shape="rectangle"
-    android:tint="?colorControlActivated">
+    app:tint="?colorControlActivated">
 
     <corners
         android:topLeftRadius="44dp"

--- a/library/src/main/res/drawable/afs_thumb.xml
+++ b/library/src/main/res/drawable/afs_thumb.xml
@@ -22,8 +22,9 @@
   -->
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" 
     android:shape="rectangle"
-    android:tint="?colorControlActivated">
+    app:tint="?colorControlActivated">
 
     <size android:width="8dp" android:height="48dp" />
 

--- a/library/src/main/res/drawable/afs_thumb_stateful.xml
+++ b/library/src/main/res/drawable/afs_thumb_stateful.xml
@@ -23,13 +23,14 @@
   -->
 <selector
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" 
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="UnusedResources">
 
     <item android:state_pressed="true">
         <shape
             android:shape="rectangle"
-            android:tint="?colorControlActivated">
+            app:tint="?colorControlActivated">
             <size android:width="8dp" android:height="48dp" />
             <solid android:color="@android:color/white" />
         </shape>
@@ -38,7 +39,7 @@
     <item>
         <shape
             android:shape="rectangle"
-            android:tint="?colorControlNormal">
+            app:tint="?colorControlNormal">
             <size android:width="8dp" android:height="48dp" />
             <solid android:color="@android:color/white" />
         </shape>

--- a/library/src/main/res/drawable/afs_track.xml
+++ b/library/src/main/res/drawable/afs_track.xml
@@ -22,8 +22,9 @@
   -->
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" 
     android:shape="rectangle"
-    android:tint="?colorControlNormal">
+    app:tint="?colorControlNormal">
 
     <size android:width="8dp" />
 


### PR DESCRIPTION
We discovered a Configuration Compatibility bug in your library through our repair tool. This issue may cause some patterns to display incorrectly across different API levels. Therefore, we recommend changing `android:tint` to `app:tint`. And it is aligned with [other users’ repairing suggestions](https://forum.devtalk.com/t/kotlin-and-android-development-featuring-jetpack-android-tint-vs-app-tint-chapter-7-p186/23803).  Additionally, your library is currently referenced by many other active apps, so we have submitted this PR and hope to receive your response.